### PR TITLE
Fix installer for a Mark 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 ## Stephen Hawking
-Tribute to stephen hawking
+Tribute to Stephen Hawking
 
 ## Description
-"My goal is simple. It is a complete understanding of the universe, why it is as it is and why it exists at all." -Stephen Hawking, 1942 - 2018
+"My goal is simple. It is a complete understanding of the universe,
+why it is as it is and why it exists at all."
+
+  -- Stephen Hawking, 1942 - 2018
 
 ## Examples
- * "when was stephen hawking born"
- * "when did stephen hawking die"
- * "quote from stephen hawking"
+* "When was Stephen Hawking born?"
+* "When did Stephen Hawking die?"
+* "Quote from Stephen Hawking"
 
 ## Credits
 JarbasAI
-

--- a/__init__.py
+++ b/__init__.py
@@ -37,4 +37,3 @@ class StephenHawkingSkill(MycroftSkill):
 
 def create_skill():
     return StephenHawkingSkill()
-

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,4 +1,4 @@
-# The requirements.sh is an advanced mechanism an should rarely be needed.
+# The requirements.sh is an advanced mechanism and should rarely be needed.
 # Be aware that it won't run with root permissions and 'sudo' won't work
 # in most cases.
 
@@ -12,6 +12,11 @@ if [ "$dist"  == "Arch"  ]; then
 elif [ "$dist" ==  "Ubuntu" ] || [ "$dist" == "KDE" ] || [ "$dist" == "Debian" ]; then
     pm="apt install"
     dependencies=( espeak )
+elif [ "$dist" == "Raspbian" ]; then
+    # Can't do 'sudo' with standard MSM install on a Mark 1 or Picroft,
+    # use pkcon instead which doesn't need sudo
+    pkcon install espeak
+    exit
 fi
 
 


### PR DESCRIPTION
Add support for Raspbian (e.g. on a Mark 1) by using the pkcon package
manager.

Also scratched my OCD itches in the README.